### PR TITLE
remove import android.support.annotation.RequiresPermission

### DIFF
--- a/android/src/main/java/com/localz/RNPinch.java
+++ b/android/src/main/java/com/localz/RNPinch.java
@@ -1,7 +1,6 @@
 package com.localz;
 
 import android.os.AsyncTask;
-import android.support.annotation.RequiresPermission;
 import android.util.Log;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageInfo;


### PR DESCRIPTION
I removed

**import android.support.annotation.RequiresPermission;**

from file

**android/src/main/java/com/localz/RNPinch.java**

since it create error on my react native code recently. and i fix my own code by comment or remove this unused import directly from node_modules file.